### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <commons_lang3_version>3.1</commons_lang3_version>
     <commons_lang_version>2.6</commons_lang_version>
-    <commons_collections_version>3.2.1</commons_collections_version>
+    <commons_collections_version>3.2.2</commons_collections_version>
     <commons_math_version>2.1</commons_math_version>
     <commons_net_version>1.4.1</commons_net_version>
     <commons_el_version>1.0</commons_el_version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
